### PR TITLE
[FEAT] LangGraph 하위 에이전트 추가 연결

### DIFF
--- a/perfume_recommendation/main.py
+++ b/perfume_recommendation/main.py
@@ -2,7 +2,7 @@ import sys
 import os
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from fastapi import FastAPI
-from perfume_recommendation.routers import llm_router, image_processing_router, image_generation_router, image_generation_description_router, diffuser_router, similar , perfume_router
+from perfume_recommendation.routers import llm_router, image_processing_router, image_generation_router, image_generation_description_router, diffuser_router, similar , product_router
 from perfume_recommendation.routers import llm_router, image_processing_router, image_generation_router, image_generation_description_router, diffuser_router, similar, review_summary_router
 from fastapi.middleware.cors import CORSMiddleware
 from dotenv import load_dotenv
@@ -43,7 +43,7 @@ app.include_router(image_generation_router.router, prefix="/image-generation", t
 app.include_router(image_generation_description_router.router, prefix="/llm" , tags=["LLM-Image-Description"])
 app.include_router(diffuser_router.router, prefix="/diffuser", tags=["Diffuser"])
 app.include_router(similar.router, prefix="/similar", tags=["Similar"])
-app.include_router(perfume_router.router, prefix="/perfume", tags=["Perfume"])
+app.include_router(product_router.router, prefix="/perfume", tags=["Product"])
 app.include_router(review_summary_router.router, prefix="/review", tags=["Review"])
 
 # Uvicorn 실행을 위한 엔트리 포인트

--- a/perfume_recommendation/routers/perfume_router.py
+++ b/perfume_recommendation/routers/perfume_router.py
@@ -1,18 +1,20 @@
 from fastapi import APIRouter, Depends
-from services.perfume_service import PerfumeService
+from services.perfume_service import ProductService
 from pydantic import BaseModel
+from typing import Optional
 
 router = APIRouter()
 
 class UserRequest(BaseModel):
     user_input: str
+    image_caption: Optional[str] = None
 
-def get_perfume_service():
-    return PerfumeService()
+def get_product_service():
+    return ProductService()
 
 @router.post("/recommend")
-async def recommend_perfume(
+async def recommend_product(
     request: UserRequest, 
-    perfume_service: PerfumeService = Depends(get_perfume_service)
+    product_service: ProductService = Depends(get_product_service)
 ):
-    return perfume_service.run(request.user_input)
+    return product_service.run(request.user_input, request.image_caption)

--- a/perfume_recommendation/routers/product_router.py
+++ b/perfume_recommendation/routers/product_router.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends
-from services.perfume_service import ProductService
+from services.product_service import ProductService
 from pydantic import BaseModel
 from typing import Optional
 

--- a/perfume_recommendation/services/llm_service.py
+++ b/perfume_recommendation/services/llm_service.py
@@ -882,7 +882,7 @@ Response:"""
         It returns 2 (default) if the user asks for neither or if there is an error.
         """
         product_category_prompt = f"""
-        Given the user input "{user_input}", determine whether the user is asking for a diffuser or a perfume recommendation. 
+        Given the user input, determine whether the user is asking for a diffuser or a perfume recommendation. 
         1. Perfume (향수 추천)
         2. Diffuser (디퓨저 추천)
 
@@ -893,16 +893,23 @@ Response:"""
         Respond with only a number: 1 or 2.
 
         ### Example 1:
-        Input: "기분 좋은 향기가 나는 디퓨저를 추천해줘."
-        Output: 2
+        User input: "기분 좋은 향기가 나는 디퓨저를 추천해줘."
+        Response: 2
 
         ### Example 2:
-        Input: "피로를 풀어주는 향수를 추천해줘."
-        Output: 1
+        User input: "피로를 풀어주는 향수를 추천해줘."
+        Response: 1
 
         ### Example 3:
-        Input: "스트레스 해소에 도움이 되는 향기를 추천해줘."
-        Output: 2
+        User input: "스트레스 해소에 도움이 되는 제품을 추천해줘."
+        Response: 2
+
+        ### Important Rule:
+        If the user input mentions 향수 (perfume), return 1.
+        If the input mentions 디퓨저 (diffuser) or does not mention either, return 2.
+
+        User input: {user_input}
+        Response: 
         """
 
         category_id = 2  # Default category_id is set to 2 (for diffuser)

--- a/perfume_recommendation/services/llm_service.py
+++ b/perfume_recommendation/services/llm_service.py
@@ -27,7 +27,7 @@ class LLMService:
         # Initialize vector database
         self.collection = self.initialize_vector_db(self.all_diffusers, self.diffuser_scent_descriptions)
 
-    def process_input(self, user_input: str) -> Tuple[str, Optional[int]]:
+    def process_input(self, user_input: str, image_caption: Optional[str] = None) -> Tuple[str, Optional[int]]:
         """
         사용자 입력을 분석하여 의도를 분류합니다.
         """
@@ -54,13 +54,11 @@ class LLMService:
 
             if "3" in intent:
                 logger.info("👕 패션 기반 향수 추천 실행 (mode는 recommendation 유지)")
-                return "recommendation", self.fashion_based_generate_recommendation_response(user_input)
+                return "recommendation", self.fashion_based_generate_recommendation_response(user_input, image_caption)
             
             if "4" in intent:
                 logger.info("🏡 공간 기반 디퓨저 추천 실행")
-                # TODO: Get image caption and remove sample_image_caption
-                sample_image_caption = "The image shows a modern living room with a large window on the right side. The room has white walls and wooden flooring. On the left side of the room, there is a gray sofa and a white coffee table with a black and white patterned rug in front of it. In the center of the image, there are six black chairs arranged around a wooden dining table. The table is set with a vase and other decorative objects on it. Above the table, two large windows let in natural light and provide a view of the city outside. A white floor lamp is placed on the floor next to the sofa."
-                return "recommendation", self.generate_interior_design_based_recommendation_response(user_input, sample_image_caption)
+                return "recommendation", self.generate_interior_design_based_recommendation_response(user_input, image_caption)
             
             if "5" in intent:
                 logger.info("🌏 테라피 목적 향수 추천 실행")
@@ -72,7 +70,7 @@ class LLMService:
             logger.error(f"Error processing input '{user_input}': {e}")
             raise HTTPException(status_code=500, detail="Failed to classify user intent.")
 
-    def extract_keywords_from_input(self, user_input: str) -> dict:
+    def extract_keywords_from_input(self, user_input: str, image_caption: Optional[str] = None) -> dict:
         """사용자 입력에서 계열과 브랜드를 분석하고 계열 ID와 브랜드 리스트를 반환하는 함수"""
         try:
             logger.info(f"🔍 입력된 텍스트에서 향 계열과 브랜드 분석 시작: {user_input}")
@@ -82,63 +80,97 @@ class LLMService:
             line_mapping = {line["name"]: line["id"] for line in line_data}
             brand_list = self.db_service.fetch_brands()
 
-            fashion_to_line_mapping = {
-                # 캐주얼 스타일
-                "캐주얼": "Fruity",
-                "댄디 캐주얼": "Woody",  # 댄디하면서도 세련된 스타일
-                "아메카지": "Green",  # 내추럴하면서 빈티지한 느낌  
+            # fashion_to_line_mapping = {
+            #     # 캐주얼 스타일
+            #     "캐주얼": "Fruity",
+            #     "댄디 캐주얼": "Woody",  # 댄디하면서도 세련된 스타일
+            #     "아메카지": "Green",  # 내추럴하면서 빈티지한 느낌  
 
-                # 클래식 & 포멀 스타일
-                "클래식": "Woody",
-                "비즈니스 포멀": "Musk",  # 정장 착장에 어울리는 차분한 향
-                "비즈니스 캐주얼": "Citrus",  # 가벼운 포멀 룩에 잘 맞는 시원한 향
-                "젠틀한 스타일": "Powdery",  # 부드러운 분위기를 주는 Powdery 향  
+            #     # 클래식 & 포멀 스타일
+            #     "클래식": "Woody",
+            #     "비즈니스 포멀": "Musk",  # 정장 착장에 어울리는 차분한 향
+            #     "비즈니스 캐주얼": "Citrus",  # 가벼운 포멀 룩에 잘 맞는 시원한 향
+            #     "젠틀한 스타일": "Powdery",  # 부드러운 분위기를 주는 Powdery 향  
 
-                # 스트릿 & 유니크 스타일
-                "스트릿": "스파이시",
-                "테크웨어": "아로마틱",  # SF적이고 미래적인 느낌의 패션과 어울림
-                "고프코어": "Green",  # 등산 및 아웃도어 느낌의 스타일과 자연스러운 향
-                "펑크 스타일": "Tobacco Leather",  # 강렬한 락 & 펑크 무드  
+            #     # 스트릿 & 유니크 스타일
+            #     "스트릿": "스파이시",
+            #     "테크웨어": "아로마틱",  # SF적이고 미래적인 느낌의 패션과 어울림
+            #     "고프코어": "Green",  # 등산 및 아웃도어 느낌의 스타일과 자연스러운 향
+            #     "펑크 스타일": "Tobacco Leather",  # 강렬한 락 & 펑크 무드  
 
-                # 스포티 & 액티브 스타일
-                "스포티": "Citrus",
-                "러너 스타일": "Aquatic",  # 활동적이고 신선한 느낌  
-                "테니스 룩": "Fougere",  # 클래식하면서도 깨끗한 향  
+            #     # 스포티 & 액티브 스타일
+            #     "스포티": "Citrus",
+            #     "러너 스타일": "Aquatic",  # 활동적이고 신선한 느낌  
+            #     "테니스 룩": "Fougere",  # 클래식하면서도 깨끗한 향  
 
-                # 빈티지 & 감성적인 스타일
-                "빈티지": "Oriental",
-                "로맨틱 스타일": "Floral",  # 부드럽고 달콤한 분위기의 스타일  
-                "보헤미안": "Musk",  # 자연스럽고 몽환적인 분위기  
-                "레트로 패션": "Aldehyde",  # 70~80년대 스타일과 어울리는 클래식한 향  
+            #     # 빈티지 & 감성적인 스타일
+            #     "빈티지": "Oriental",
+            #     "로맨틱 스타일": "Floral",  # 부드럽고 달콤한 분위기의 스타일  
+            #     "보헤미안": "Musk",  # 자연스럽고 몽환적인 분위기  
+            #     "레트로 패션": "Aldehyde",  # 70~80년대 스타일과 어울리는 클래식한 향  
 
-                # 모던 & 미니멀 스타일
-                "모던": "Woody",
-                "미니멀": "Powdery",  # 깨끗하고 단정한 분위기  
-                "올 블랙 룩": "Tobacco Leather",  # 강렬하면서 시크한 무드  
-                "화이트 톤 스타일": "Musk",  # 깨끗하고 부드러운 느낌  
+            #     # 모던 & 미니멀 스타일
+            #     "모던": "Woody",
+            #     "미니멀": "Powdery",  # 깨끗하고 단정한 분위기  
+            #     "올 블랙 룩": "Tobacco Leather",  # 강렬하면서 시크한 무드  
+            #     "화이트 톤 스타일": "Musk",  # 깨끗하고 부드러운 느낌  
 
-                # 독특한 컨셉 스타일
-                "아방가르드": "Tobacco Leather",  # 예술적인 스타일과 어울리는 가죽 향  
-                "고딕 스타일": "Oriental",  # 다크하면서 무게감 있는 향  
-                "코스프레": "Gourmand",  # 달콤하면서 개성 강한 스타일  
-            }
+            #     # 독특한 컨셉 스타일
+            #     "아방가르드": "Tobacco Leather",  # 예술적인 스타일과 어울리는 가죽 향  
+            #     "고딕 스타일": "Oriental",  # 다크하면서 무게감 있는 향  
+            #     "코스프레": "Gourmand",  # 달콤하면서 개성 강한 스타일  
+            # }
             
             # 2. GPT를 이용해 입력에서 향 계열과 브랜드 추출
             keywords_prompt = (
-                "다음은 향수 추천 요청입니다. 사용자의 입력에서 향 계열과 브랜드명을 추출하세요.\n"
-                f"향 계열 목록: {', '.join(line_mapping.keys())}\n"
-                f"브랜드 목록: {', '.join(brand_list)}\n\n"
-                f"사용자 입력: {user_input}\n\n"
-                "추가 규칙: 만약 사용자의 입력이 패션 스타일에 대한 설명이라면, 다음 패션 스타일과 어울리는 향 계열을 사용하세요.\n"
-                "추가 규칙: 만약 사용자의 입력이 데이트나 특정 상황에 대한 설명이라면, 다음 상황에 어울리는 향 계열을 사용하세요.\n"
-                f"{json.dumps(fashion_to_line_mapping, ensure_ascii=False, indent=2)}\n\n"
-                "출력 형식은 JSON이어야 합니다:\n"
+                "The following is a perfume recommendation request. Extract the fragrance family and brand names from the user_input and image_caption.\n"
+                f"Fragrance families: {', '.join(line_mapping.keys())}\n"
+                f"Brand list: {', '.join(brand_list)}\n\n"
+
+                "Additional rules: If the user_input and the image_caption is a description of a fashion style, use the corresponding fragrance family from the following fashion styles.\n"
+                "Additional rules: If the user_input is a description of a date or a specific situation, use the corresponding fragrance family for the situation.\n"
+                "Additional rules: Infer the user's style or vibe from the the user_input or image_caption (e.g., sporty, romantic, vintage, etc.) and recommend a fragrance family based on that.\n\n"
+                
+                "### Fashion style to fragrance family(line) mapping example:\n"
+                "1. Casual style -> line: Fruity\n"
+                "2. Dandy Casual -> line: Woody\n"
+                "3. American Casual -> line: Green\n"
+                "4. Classic -> line: Woody\n"
+                "5. Business Formal -> line: Musk\n"
+                "6. Business Casual -> line: Citrus\n"
+                "7. Gentle Style -> line: Powdery\n"
+                "8. Street -> line: Spicy\n"
+                "9. Techwear -> line: Aromatic\n"
+                "10. Gorp Core -> line: Green\n"
+                "11. Punk Style -> line: Tobacco Leather\n"
+                "12. Sporty -> line: Citrus\n"
+                "13. Runner Style -> line: Aquatic\n"
+                "14. Tennis Look -> line: Fougere\n"
+                "15. Vintage -> line: Oriental\n"
+                "16. Romantic Style -> line: Floral\n"
+                "17. Bohemian -> line: Musk\n"
+                "18. Retro Fashion -> line: Aldehyde\n"
+                "19. Modern -> line: Woody\n"
+                "20. Minimal -> line: Powdery\n"
+                "21. All Black Look -> line: Tobacco Leather\n"
+                "22. White Tone Style -> line: Musk\n"
+                "23. Avant-garde -> line: Tobacco Leather\n"
+                "24. Gothic Style -> line: Oriental\n"
+                "25. Cosplay -> line: Gourmand\n\n"
+
+                "### Important rule: The 'line' must **never** be null. It should always correspond to **one of the Fragrance families listed above**.\n\n"
+                "### The output format must be **JSON**:\n"
                 "{\n"
-                '  "line": "우디",\n'
+                '  "line": "Woody",\n'
                 '  "brands": ["샤넬", "딥티크"]\n'
                 "}"
+
+                f"\n\n### user_input: {user_input}"
             )
 
+            if keywords_prompt is not None:
+                keywords_prompt += f"\n### image_caption: {image_caption}"
+            
             response_text = self.gpt_client.generate_response(keywords_prompt).strip()
             logger.info(f"🤖 GPT 응답: {response_text}")
 
@@ -447,14 +479,14 @@ class LLMService:
             logger.error(f"❌ 예상치 못한 오류: {e}")
             return 1
         
-    def fashion_based_generate_recommendation_response(self, user_input: str) -> dict:
+    def fashion_based_generate_recommendation_response(self, user_input: str, image_caption: str) -> dict:
         """middle note를 포함한 향수 추천"""
         try:
             logger.info(f"🔄 추천 처리 시작 - 입력: {user_input}")
 
             # 1. 키워드 추출 
             logger.info("🔍 키워드 추출 시작")
-            extracted_data = self.extract_keywords_from_input(user_input)
+            extracted_data = self.extract_keywords_from_input(user_input, image_caption)
             line_id = extracted_data["line_id"]
             brand_filters = extracted_data["brands"]
             logger.info(f"✅ 추출된 키워드 - 계열ID: {line_id}, 브랜드: {brand_filters}")
@@ -493,13 +525,13 @@ class LLMService:
             names_prompt = (
                 f"{template['description']}\n"
                 f"{template['rules']}\n"
-                f"사용자의 원본 입력: {user_input}\n\n"
-                f"아래 입력을 한국어로 번역한 후 향수를 추천하세요:\n"
-                f"{user_input}\n\n"
-                f"추출된 키워드: {products_text}\n"
-                f"향수의 브랜드 이름은 포함하지 않은 이름만 최대 3개 추천해주세요.\n\n"
-                f"- content: 추천 이유와 사용 상황, 향수들의 공통적인 느낌을 함께 적어주세요.\n\n"
-                "아래 JSON 형식으로만 응답하세요:\n"
+                f"### user_input: {user_input}\n\n"
+                f"### image_caption: {image_caption}\n\n"
+                f"### Extracted keywords: {products_text}\n"
+                f"Recommend up to 3 perfume names without including the brand names.\n\n"
+                f"Note: The recommendations should refer to the user_input, image_caption, and extracted keywords. The image_caption describes the person's outfit, and the recommended perfumes should match the described outfit.\n"
+                f"- content: Please include the reason for the recommendation, the situation it suits, and the common feel of the perfumes.\n\n"
+                "Please respond only in the following JSON format:\n"
                 "```json\n"
                 "{\n"
                 '  "recommendations": [\n'

--- a/perfume_recommendation/services/product_service.py
+++ b/perfume_recommendation/services/product_service.py
@@ -51,6 +51,7 @@ class ProductState(TypedDict):
     processed_input: str  
     next_node: str
     recommendations: Optional[list]
+    recommendation_type: Optional[int]
     spices: Optional[list]
     image_path: Optional[str]
     response: Optional[str]
@@ -229,10 +230,10 @@ class ProductService:
 
             type_prompt = (
                 f"Please divide the perfume/diffuser recommendations based on the following criteria:\n\n"
-                f"1. **Fashion-based Recommendation (3)**: Recommend a fragrance that matches the style of clothes the person is wearing. This should be based on the image description of the outfit. If the image_caption describes mostly the person and their outfit, it should return 3.\n"
-                f"2. **General Recommendation (4)**: Recommend a fragrance based on the user's preferred scent.\n"
-                f"3. **Interior Description-based Recommendation (5)**: Recommend a fragrance based on the image description of the room or space. If the image_caption describes mostly the space or interior, it should return 5.\n"
-                f"4. **Therapy-based Recommendation (6)**: Recommend a fragrance based on the user's mood or emotional state. Categories include:\n"
+                f"1. **General Recommendation (1)**: Recommend a fragrance based on the user's preferred scent.\n"
+                f"2. **Fashion-based Recommendation (2)**: Recommend a fragrance that matches the style of clothes the person is wearing. This should be based on the image description of the outfit. If the image_caption describes mostly the person and their outfit, it should return 2.\n"
+                f"3. **Interior Description-based Recommendation (3)**: Recommend a fragrance based on the image description of the room or space. If the image_caption describes mostly the space or interior, it should return 3.\n"
+                f"4. **Therapy-based Recommendation (4)**: Recommend a fragrance based on the user's mood or emotional state. Categories include:\n"
                 f"    - 스트레스 감소 (Stress Relief)\n"
                 f"    - 행복 (Happiness)\n"
                 f"    - 리프레시 (Refreshment)\n"
@@ -241,22 +242,22 @@ class ProductService:
                 f"    - 에너지 (Energy)\n\n"
                 
                 f"### Examples)\n"
-                f"1) **Fashion-based Recommendation**: \n"
+                f"1) **General Recommendation**: \n"
+                f"    user_input = '상큼한 향이 나는 향수를 추천해줘'\n"
+                f"    response: 1\n\n"
+                f"2) **Fashion-based Recommendation**: \n"
                 f"    user_input = '오늘 입은 옷에 어울리는 향수가 필요해'\n"
                 f"    image_caption = 'The image shows a young man walking on a street. He is wearing a grey coat with a black and white checkered pattern, a navy blue shirt, beige trousers, and brown shoes. He has short dark hair and is looking off to the side with a serious expression on his face. The street is lined with buildings and there are cars parked on the side. The sky is overcast and the overall mood of the image is casual and relaxed.'\n"
-                f"    response: 3\n\n"
-                f"2) **General Recommendation**: \n"
-                f"    user_input = '상큼한 향이 나는 향수를 추천해줘'\n"
-                f"    response: 4\n\n"
+                f"    response: 2\n\n"
                 f"3) **Interior Description-based Recommendation**: \n"
                 f"    user_input = '시트러스 향이 나는 향수를 추천해주세요.'\n"
                 f"    image_caption = 'The image shows a modern living room with a large window on the right side. The room has white walls and wooden flooring. On the left side of the room, there is a gray sofa and a white coffee table with a black and white patterned rug in front of it. In the center of the image, there are six black chairs arranged around a wooden dining table. The table is set with a vase and other decorative objects on it. Above the table, two large windows let in natural light and provide a view of the city outside. A white floor lamp is placed on the floor next to the sofa.'\n"
-                f"    response: 5\n\n"
+                f"    response: 3\n\n"
                 f"4) **Therapy-based Recommendation**: \n"
                 f"    user_input = '스트레스 해소에 좋은 디퓨저를 추천해주세요'\n"
-                f"    response: 6\n\n"
+                f"    response: 4\n\n"
 
-                f"### Intention: (3) Fashion Recommendation, (4) General Recommendation, (5) Interior Description-based Recommendation, (6) Therapy-based Recommendation\n\n"
+                f"### Intention: (1) General Recommendation, (2) Fashion Recommendation, (3) Interior Description-based Recommendation, (4) Therapy-based Recommendation\n\n"
                 f"### user_input = {user_input}"
             )
 
@@ -267,27 +268,32 @@ class ProductService:
             recommendation_type = self.gpt_client.generate_response(type_prompt).strip()
             logger.info(f"Detected recommendation type: {recommendation_type}")
 
-            if "3" in recommendation_type:
+            if "2" in recommendation_type:
                 logger.info("👕 패션 기반 향수 추천 실행")
                 state["processed_input"] = "fashion_recommendation"
                 state["next_node"] = "fashion_recommendation_generator"
-            elif "5" in recommendation_type:
+                state["recommendation_type"] = 2
+            elif "3" in recommendation_type:
                 logger.info("🏠 인테리어 사진 기반 향수 추천 실행")
                 state["processed_input"] = "interior_recommendation"
                 state["next_node"] = "interior_recommendation_generator"
-            elif "6" in recommendation_type:
+                state["recommendation_type"] = 3
+            elif "4" in recommendation_type:
                 logger.info("🌏 테라피 기반 향수 추천 실행")
                 state["processed_input"] = "therapy_recommendation"
                 state["next_node"] = "therapy_recommendation_generator"
+                state["recommendation_type"] = 4
             else:
                 logger.info("✨ 일반 향수 추천 실행")
                 state["processed_input"] = "general_recommendation"
                 state["next_node"] = "recommendation_generator"
+                state["recommendation_type"] = 1
         
         except Exception as e:
             logger.error(f"Error processing recommendation type '{user_input}': {e}")
             state["processed_input"] = "general_recommendation"
             state["next_node"] = "recommendation_generator"
+            state["recommendation_type"] = 1
         
         return state
     
@@ -378,7 +384,8 @@ class ProductService:
                         "mode": "recommendation",
                         "recommendations": recommendations,
                         "content": content,
-                        "line_id": line_id
+                        "line_id": line_id,
+                        "recommendation_type": state["recommendation_type"]
                     }
 
                     # 이미지 생성 시도
@@ -414,7 +421,8 @@ class ProductService:
                             "mode": "recommendation",
                             "recommendations": filtered_products,
                             "content": "향료 기반으로 추천된 향수입니다.",
-                            "line_id": state.get("line_id", 1)
+                            "line_id": state.get("line_id", 1),
+                            "recommendation_type": state["recommendation_type"]
                         }
 
                         # 이미지 생성 시도
@@ -466,7 +474,8 @@ class ProductService:
                         "mode": "recommendation",
                         "recommendations": recommendations,
                         "content": content,
-                        "line_id": line_id
+                        "line_id": line_id,
+                        "recommendation_type": state["recommendation_type"]
                     }
 
                     # 이미지 생성 시도
@@ -503,7 +512,8 @@ class ProductService:
                             "mode": "fashion_recommendation",
                             "recommendation": filtered_products,
                             "content": "향료 기반으로 추천된 향수입니다.",
-                            "line_id": state.get("line_id", 1)
+                            "line_id": state.get("line_id", 1),
+                            "recommendation_type": state["recommendation_type"]
                         }
 
                         # 이미지 생성 시도
@@ -554,7 +564,8 @@ class ProductService:
                         "mode": "recommendation",
                         "recommendations": recommendations,
                         "content": content,
-                        "line_id": line_id
+                        "line_id": line_id,
+                        "recommendation_type": state["recommendation_type"]
                     }
 
                     # 이미지 생성 시도
@@ -605,7 +616,8 @@ class ProductService:
                         "mode": "recommendation",
                         "recommendations": recommendations,
                         "content": content,
-                        "line_id": line_id
+                        "line_id": line_id,
+                        "recommendation_type": state["recommendation_type"]
                     }
 
                     # 이미지 생성 시도
@@ -647,7 +659,8 @@ class ProductService:
     #         "mode": "recommendation",
     #         "recommendation": recommendations,
     #         "content": content,
-    #         "line_id": line_id
+    #         "line_id": line_id,
+    #         "recommendation_type": state["recommendation_type"]
     #     }
 
     #     # 이미지 생성 시도
@@ -886,6 +899,7 @@ class ProductService:
                 "processed_input": None,
                 "next_node": None,
                 "recommendations": None,
+                "recommendation_type": None,
                 "spices": None,
                 "image_path": None,
                 "response": None,


### PR DESCRIPTION
- mid-level supervisor 에이전트(recommendation_type_classifier)에서 추가적인 하위 에이전트(공간 디자인 기반 디퓨저 추천 기능과 테라피 목적 향수/디퓨저 추천 기능) route할 수 있게 추가
- top-level supervisor 에이전트에서 prompt 강화, user_input 뿐 아니라 image_caption도 존재한다면 참고하여 예상치 못한 추천 카테고리로 route 되는 것 방지
- 패션 향수 추천 기능에서
    - extract_keywords_from_input() 에서 특정 키워드가 존재하지 않으면 무조건 null을 반환하는 오류 수정
    - image_caption을 참고하게 수정
- response에 추천 타입 추가하여 반환 (1: 일반추천, 2: 패션, 3: 인테리어, 4: 테라피)